### PR TITLE
Feature branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Just create new _blade_ template file!
       });
   </script>
 ```
-*used in [Laracast - Flash Messaging](https://laracasts.com/series/laravel-5-fundamentals/episodes/20)
+used in [Laracast - Flash Messaging](https://laracasts.com/series/laravel-5-fundamentals/episodes/20)
 
 *[jQuery](https://jquery.com) has to be included!*
 

--- a/README.md
+++ b/README.md
@@ -65,19 +65,25 @@ Flash::error('Oh snap!', 'Something went wrong. Please try again for a few secon
 
 ## Custom alert view
 
-Package default provides _bootstrap ready_ view for alerts. You can define own style for it. 
+Package default provides _bootstrap ready_ view for alerts. You can define own style for it.
 Just create new _blade_ template file!
 
 ```php
 @if(Session::has('flash.alerts'))
     @foreach(Session::get('flash.alerts') as $alert)
 
-        <div class='alert alert-{{ $alert['level'] }}'>
-            <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&times;</button>
+          @if($alert['important'])
+            <div class='alert alert-{{ $alert['level'] }} alert-important'>
 
-            @if( ! empty($alert['title']))
-                <div><strong>{{ $alert['title'] }}</strong></div>
-            @endif
+            <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&times;</button>
+          @else
+            <div class='alert alert-{{ $alert['level'] }}'>
+
+          @endif
+
+          @if( ! empty($alert['title']))
+              <div><strong>{{ $alert['title'] }}</strong></div>
+          @endif
 
             {{ $alert['message'] }}
         </div>
@@ -86,10 +92,34 @@ Just create new _blade_ template file!
 @endif
 ```
 
+*Example Script for a Basic slideUp*
+
+```javascript
+  <script>
+      $( document).ready( function(){
+        $('div.alert').not('.alert-important').delay(3000).slideUp(300);
+      });
+  </script>
+```
+*used in [Laracast - Flash Messaging](https://laracasts.com/series/laravel-5-fundamentals/episodes/20)
+
+*[jQuery](https://jquery.com) has to be included!*
+
+###### Including jQuery
+* [CDN](https://code.jquery.com/jquery-2.1.4.js)
+* Composer:
+  * ``` "require": {
+        "components/jquery": "1.9.*"
+        }```
+* Bower:
+  * ```bower install jQuery```
+* [GitHub/jQuery](https://github.com/jquery)
+
 All alerts will be in `flash.alerts` session variable. Single alert looks like:
 
 ```php
 [
+  'important' => TRUE
   'title' => 'Title',
   'message' => 'Example message',
   'level' => 'success'

--- a/spec/Szykra/Notifications/FlashNotifierSpec.php
+++ b/spec/Szykra/Notifications/FlashNotifierSpec.php
@@ -18,14 +18,19 @@ class FlashNotifierSpec extends ObjectBehavior
         $this->shouldHaveType('Szykra\Notifications\FlashNotifier');
     }
 
-    function it_should_throw_exception_when_provide_more_than_two_parameters()
+    function it_should_throw_exception_when_provide_more_than_three_parameters()
     {
-    	$this->shouldThrow('\InvalidArgumentException')->duringInfo("Dummy title", "Dummy message", "I have no idea what it is...");	
+    	$this->shouldThrow('\InvalidArgumentException')->duringInfo(TRUE, "Dummy title", "Dummy message", "I have no idea what it is...");
+    }
+
+		function it_should_throw_exception_when_no_boolean_value_provide()
+    {
+    	$this->shouldThrow('\InvalidArgumentException')->duringInfo("Dummy title", "Dummy message", "I have no idea what it is...");
     }
 
     function it_should_set_flash_to_session_store(Store $session)
     {
-    	$session->flash('flash.alerts', [['title' => '', 'message' => 'Test message', 'level' => 'info']])->shouldBeCalled();
+    	$session->flash('flash.alerts', [['important' => TRUE, 'title' => '', 'message' => 'Test message', 'level' => 'info']])->shouldBeCalled();
 
     	$this->info('Test message');
     }

--- a/src/Szykra/Notifications/FlashNotifier.php
+++ b/src/Szykra/Notifications/FlashNotifier.php
@@ -75,25 +75,28 @@ class FlashNotifier {
      *
      * @param $args
      * @param $level
+     * @param $important
      * @return $this
      */
     protected function message($args, $level)
     {
         switch(count($args))
         {
+            case 3:
+              $important = $args[0];
+              $title = $args[1];
+              $message = $args[2];
+              break;
             case 2:
-                $title = $args[0];
-                $message = $args[1];
-                break;
-            case 1:
+                $important = $args[0];
                 $title = '';
-                $message = $args[0];
+                $message = $args[1];
                 break;
             default:
                 throw new \InvalidArgumentException('Cannot resolve arguments. Please provide one parameter as `message` or two parameters as `title` and `message`.');
         }
 
-        $this->notifies[] = ['title' => $title, 'message' => $message, 'level' => $level];
+        $this->notifies[] = ['important' => $important, 'title' => $title, 'message' => $message, 'level' => $level];
 
         $this->push();
 

--- a/src/views/flash.blade.php
+++ b/src/views/flash.blade.php
@@ -1,12 +1,18 @@
 @if(Session::has('flash.alerts'))
     @foreach(Session::get('flash.alerts') as $alert)
 
-        <div class='alert alert-{{ $alert['level'] }}'>
-            <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&times;</button>
+          @if($alert['important'])
+            <div class='alert alert-{{ $alert['level'] }} alert-important'>
 
-            @if( ! empty($alert['title']))
-                <div><strong>{{ $alert['title'] }}</strong></div>
-            @endif
+            <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&times;</button>
+          @else
+            <div class='alert alert-{{ $alert['level'] }}'>
+
+          @endif
+
+          @if( ! empty($alert['title']))
+              <div><strong>{{ $alert['title'] }}</strong></div>
+          @endif
 
             {{ $alert['message'] }}
         </div>
@@ -14,3 +20,11 @@
     @endforeach
 @endif
 
+
+@push("scripts")
+<script>
+    $( document).ready( function(){
+      $('div.alert').not('.alert-important').delay(3000).slideUp(300);
+    });
+</script>
+@endpush


### PR DESCRIPTION
### Extending and Forking The "larval-flash-notifications"

When I got in touch with Laravel I watch the [Laravel 5 Fundamentals](https://laracasts.com/series/laravel-5-fundamentals).
In one Episode the "Flash Messaging" is shown and a Laracasts-Helper is used. This Helper was to static for me so I looked for an alternative. 
After a quick websearch [laravel-flash-notifications](https://github.com/skrajewski/laravel-flash-notifications) seemed to do the job.
But there was no option to do a "slideUp"-Message without an X.

> as shown in the [Flash Messaging-Episode](https://laracasts.com/series/laravel-5-fundamentals/episodes/20)

This was essential for me so I modded the GitHub-Project.
#### Examples

> produced in a similar environment as produced in the _Laravel-Fundamentals_
###### Example One

Controller (_ArticlesController.php_):

``` php
    public function store(Requests\ArticleRequest $request) {

      Article::create($request->all());

      Flash::success(TRUE, "Saved Article", "Your Article has been saved.");

      return redirect("articles");
    }
```

VIEW:
<img width="1440" alt="importantview" src="https://cloud.githubusercontent.com/assets/10073766/9112333/467a2bd4-3c4e-11e5-9878-37478708d9b1.png">

> permanent FlashMessage with a X and a Title
###### Example Two

Controller (_ArticlesController.php_):

``` php
    public function store(Requests\ArticleRequest $request) {

      Article::create($request->all());

      Flash::success(TRUE, "Saved Article", "Your Article has been saved.");

      return redirect("articles");
    }
```

VIEW:

<img width="1440" alt="slideupview" src="https://cloud.githubusercontent.com/assets/10073766/9112439/e3df7d5c-3c4e-11e5-822f-c575e80e371e.png">

> slideUp FlashMessage without a X and without a Title

_I hope you going to like it_
I'm looking forward hearing from you!

Regards,
Enaah
